### PR TITLE
Add directory display feature for homepage (#1)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { SongList } from '@/components/song/SongList';
+import { SongDirectory } from '@/components/song/SongDirectory';
 import { SearchBar } from '@/components/search/SearchBar';
 import { loadSongs, searchSongs } from '@/lib/data';
 import { Song } from '@/lib/types';
@@ -16,6 +17,7 @@ function HomeContent() {
   const [filteredSongs, setFilteredSongs] = useState<Song[]>([]);
   const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [loading, setLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<'grid' | 'directory'>('grid');
 
   useEffect(() => {
     async function fetchData() {
@@ -79,11 +81,40 @@ function HomeContent() {
         </section>
 
         <section className="space-y-4">
-          <SearchBar
-            onSearch={handleSearch}
-            placeholder="搜索歌名、歌词或输入编号..."
-            initialValue={searchQuery}
-          />
+          <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+            <div className="flex-1 w-full sm:flex-initial">
+              <SearchBar
+                onSearch={handleSearch}
+                placeholder="搜索歌名、歌词或输入编号..."
+                initialValue={searchQuery}
+              />
+            </div>
+
+            {/* View Mode Toggle */}
+            <div className="flex bg-muted rounded-lg p-1">
+              <button
+                onClick={() => setViewMode('grid')}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  viewMode === 'grid'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                网格
+              </button>
+              <button
+                onClick={() => setViewMode('directory')}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  viewMode === 'directory'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                目录
+              </button>
+            </div>
+          </div>
+
           {searchQuery && (
             <p className="text-sm text-muted-foreground">
               找到 {filteredSongs.length} 首相关歌曲 | Found {filteredSongs.length} songs
@@ -94,8 +125,10 @@ function HomeContent() {
         <section>
           {loading ? (
             <Loading />
-          ) : (
+          ) : viewMode === 'grid' ? (
             <SongList songs={filteredSongs} />
+          ) : (
+            <SongDirectory songs={filteredSongs} />
           )}
         </section>
 

--- a/src/components/song/SongDirectory.tsx
+++ b/src/components/song/SongDirectory.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { Song } from '@/lib/types';
+
+interface SongDirectoryProps {
+  songs: Song[];
+}
+
+export function SongDirectory({ songs }: SongDirectoryProps) {
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-1 gap-2 text-sm">
+        {songs.map((song) => (
+          <SongDirectoryItem key={song.id} song={song} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SongDirectoryItem({ song }: { song: Song }) {
+  // Split bilingual title into Chinese and English parts
+  // Format: "中文标题 English Title"
+  const titleMatch = song.title.match(/^([\u4e00-\u9fff\s]+?)\s+([a-zA-Z\s]+)$/);
+
+  let cnTitle = song.title;
+  let enTitle = '';
+
+  if (titleMatch) {
+    cnTitle = titleMatch[1].trim();
+    enTitle = titleMatch[2].trim();
+  } else {
+    // If no clear separation, try to find the first English word
+    const words = song.title.split(' ');
+    const firstEnglishIndex = words.findIndex(word => /[a-zA-Z]/.test(word));
+
+    if (firstEnglishIndex > 0) {
+      cnTitle = words.slice(0, firstEnglishIndex).join(' ');
+      enTitle = words.slice(firstEnglishIndex).join(' ');
+    }
+  }
+
+  return (
+    <Link
+      href={`/song/${song.id}`}
+      className="block hover:bg-muted/50 transition-colors p-3 rounded-md border border-transparent hover:border-border"
+    >
+      <div className="flex items-center gap-4">
+        {/* Song Number */}
+        <span className="text-sm font-mono text-muted-foreground bg-muted px-2 py-1 rounded min-w-[3rem] text-center">
+          #{song.id}
+        </span>
+
+        {/* Chinese Title */}
+        <div className="flex-1 font-chinese">
+          <span className="text-foreground font-medium">{cnTitle}</span>
+        </div>
+
+        {/* Separator */}
+        <span className="text-muted-foreground">|</span>
+
+        {/* English Title */}
+        <div className="flex-1">
+          <span className="text-foreground">{enTitle}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
- Created new SongDirectory component to display songs in list format
- Added view mode toggle buttons (Grid/Directory) on homepage
- Directory view shows song number, Chinese and English titles in a clean layout
- Improved title splitting logic to properly separate bilingual titles
- Feature addresses issue #1 for traffic-focused song listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)